### PR TITLE
add responsive vote locking

### DIFF
--- a/src/components/ArticleCard.jsx
+++ b/src/components/ArticleCard.jsx
@@ -6,7 +6,9 @@ import Typography from "@mui/material/Typography";
 import { Link } from "react-router-dom";
 import IconButton from "@mui/material/IconButton";
 import ThumbDownOutlinedIcon from "@mui/icons-material/ThumbDownOutlined";
+import ThumbDownIcon from "@mui/icons-material/ThumbDown";
 import ThumbUpOutlinedIcon from "@mui/icons-material/ThumbUpOutlined";
+import ThumbUpIcon from "@mui/icons-material/ThumbUp";
 import { useContext, useState } from "react";
 import { UserContext } from "../contexts/UserContext";
 import { ncNewsPatch } from "../api/APIUtils";
@@ -15,18 +17,21 @@ export default function ArticleCard({ article }) {
   const { user } = useContext(UserContext);
   const [votes, setVotes] = useState(article.votes);
   const [err, setErr] = useState(null);
+  const [userVote, setUserVote] = useState(null);
 
   const onClickVote = (vote) => {
+    setUserVote(!userVote ? vote : null);
     setErr(null);
     setVotes((currentVotes) => currentVotes + vote);
     ncNewsPatch(`/articles/${article.article_id}`, { inc_votes: vote }).catch(
       () => {
         setVotes((currentVotes) => currentVotes - vote);
         setErr("Something went wrong, please try voting again.");
+        setUserVote(null);
       }
     );
   };
-
+  console.log(userVote, "log it");
   const formattedDate = article.created_at
     ? format(parseISO(article.created_at), "HH:ss aaa, eeee do MMM, yyyy")
     : null;
@@ -64,21 +69,31 @@ export default function ArticleCard({ article }) {
           {user ? (
             <>
               <IconButton
-                aria-label="vote up"
+                aria-label={userVote === 1 ? "remove vote up" : "vote up"}
                 color="primary"
                 size="small"
-                onClick={() => onClickVote(1)}
+                disabled={userVote === -1 ? true : false}
+                onClick={() => onClickVote(userVote ? -1 : 1)}
               >
-                <ThumbUpOutlinedIcon fontSize="inherit" />
+                {userVote === 1 ? (
+                  <ThumbUpIcon fontSize="inherit" />
+                ) : (
+                  <ThumbUpOutlinedIcon fontSize="inherit" />
+                )}
               </IconButton>
               {votes}
               <IconButton
-                aria-label="vote down"
+                aria-label={userVote === -1 ? "remove vote down" : "vote down"}
                 color="primary"
                 size="small"
-                onClick={() => onClickVote(-1)}
+                disabled={userVote === 1 ? true : false}
+                onClick={() => onClickVote(userVote ? 1 : -1)}
               >
-                <ThumbDownOutlinedIcon fontSize="inherit" />
+                {userVote === -1 ? (
+                  <ThumbDownIcon fontSize="inherit" />
+                ) : (
+                  <ThumbDownOutlinedIcon fontSize="inherit" />
+                )}
               </IconButton>
             </>
           ) : (


### PR DESCRIPTION
User can only vote once, after voting, the opposite button is disabled and the one they clicked is now filled in to indicate the vote taken. This button can now be clicked again to remove the vote and reset the buttons. Note this is not persistent as the API currently does not track user voting.