### PR TITLE
add comment deleting

### DIFF
--- a/src/api/APIUtils.js
+++ b/src/api/APIUtils.js
@@ -12,3 +12,6 @@ export function ncNewsPatch(url, request) {
 export function ncNewsPost(url, request) {
   return ncNewsApi.post(url, request);
 }
+export function ncNewsDelete(url) {
+  return ncNewsApi.delete(url);
+}

--- a/src/components/AddComment.jsx
+++ b/src/components/AddComment.jsx
@@ -8,7 +8,11 @@ import { useState, useContext } from "react";
 import { UserContext } from "../contexts/UserContext";
 import { ncNewsPost } from "../api/APIUtils";
 
-export default function AddComment({ setCommentList, article_id }) {
+export default function AddComment({
+  setCommentList,
+  article_id,
+  setArticleData,
+}) {
   const { user } = useContext(UserContext);
   const [newComment, setNewComment] = useState("");
   const [formError, setFormError] = useState(false);
@@ -33,19 +37,36 @@ export default function AddComment({ setCommentList, article_id }) {
     setCommentList((currentCommentList) => {
       return [commentObj, ...currentCommentList];
     });
+    setArticleData((currentArticle) => {
+      return {
+        ...currentArticle,
+        comment_count: ++currentArticle.comment_count,
+      };
+    });
     ncNewsPost(`/articles/${article_id}/comments`, {
       username: user.username,
       body: newComment,
     })
-      .then(() => {
+      .then(({ data: { comment } }) => {
         setSubmitted(false);
         setNewComment("");
+        setCommentList((currentCommentList) => {
+          const updatedComments = [...currentCommentList];
+          updatedComments[0].comment_id = comment.comment_id;
+          return [...updatedComments];
+        });
       })
       .catch((err) => {
         setSubmitted(false);
         setCommentList((currentCommentList) => {
           currentCommentList.shift();
           return [...currentCommentList];
+        });
+        setArticleData((currentArticle) => {
+          return {
+            ...currentArticle,
+            comment_count: --currentArticle.comment_count,
+          };
         });
         setApiErr("Something went wrong, please try commenting again.");
       });

--- a/src/components/ArticleCard.jsx
+++ b/src/components/ArticleCard.jsx
@@ -31,7 +31,6 @@ export default function ArticleCard({ article }) {
       }
     );
   };
-  console.log(userVote, "log it");
   const formattedDate = article.created_at
     ? format(parseISO(article.created_at), "HH:mm aaa, eeee do MMM, yyyy")
     : null;

--- a/src/components/CommentCard.jsx
+++ b/src/components/CommentCard.jsx
@@ -1,16 +1,50 @@
 import { format, parseISO } from "date-fns";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
+import CardActions from "@mui/material/CardActions";
+import Button from "@mui/material/Button";
 import Typography from "@mui/material/Typography";
 import { Link } from "react-router-dom";
+import { UserContext } from "../contexts/UserContext";
+import { useContext, useState } from "react";
+import { ncNewsDelete } from "../api/APIUtils";
 
-export default function CommentCard({ comment }) {
+export default function CommentCard({
+  comment,
+  setCommentList,
+  setArticleData,
+}) {
+  const { user } = useContext(UserContext);
+  const [deleteAction, setDeleteAction] = useState(false);
+  const [apiErr, setApiErr] = useState(null);
   const formattedDate = comment.created_at
     ? format(parseISO(comment.created_at), "HH:mm aaa, eeee do MMM, yyyy")
     : null;
+
+  const handleDelete = () => {
+    setDeleteAction(true);
+    setApiErr(null);
+    ncNewsDelete(`comments/${comment.comment_id}`)
+      .then(() => {
+        setArticleData((currentArticle) => {
+          return {...currentArticle, comment_count: --currentArticle.comment_count};
+        });
+        setCommentList((currentCommentList) => {
+          const updatedComments = currentCommentList.filter(
+            (thisComment) => thisComment.comment_id !== comment.comment_id
+          );
+          return [...updatedComments];
+        });
+      })
+      .catch(() => {
+        setDeleteAction(false);
+        setApiErr("Something went wrong, please try deleting again.");
+      });
+  };
+
   return (
-    <Card sx={{ maxWidth: 800, width: 1, marginTop: 1  }}>
-      <CardContent>
+    <Card sx={{ maxWidth: 800, width: 1, marginTop: 1 }}>
+      <CardContent sx={{ padding: "1px" }}>
         <Typography variant="body1" color="text.secondary" sx={{ paddingY: 1 }}>
           {comment.body}
         </Typography>
@@ -19,6 +53,27 @@ export default function CommentCard({ comment }) {
         </Typography>
         <Typography variant="overline">Rating: {comment.votes}</Typography>
       </CardContent>
+      {comment.author === user.username ? (
+        <CardActions sx={{ paddingTop: 0 }}>
+          <Button
+            variant="contained"
+            size="small"
+            disabled={deleteAction}
+            sx={{ marginLeft: "auto", marginRight: "auto" }}
+            onClick={handleDelete}
+          >
+            {deleteAction ? "Deleting Comment..." : "Delete Comment"}
+          </Button>
+        </CardActions>
+      ) : null}{" "}
+      {apiErr ? (
+        <Typography
+          variant="subtitle2"
+          sx={{ lineHeight: 1, paddingBottom: 1 }}
+        >
+          {apiErr}
+        </Typography>
+      ) : null}
     </Card>
   );
 }

--- a/src/components/SingleArticle.jsx
+++ b/src/components/SingleArticle.jsx
@@ -16,7 +16,6 @@ export default function SingleArticle() {
   const [isError, setIsError] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const { id } = useParams();
-
   useEffect(() => {
     setIsLoading(true);
     Promise.all([
@@ -40,16 +39,32 @@ export default function SingleArticle() {
   return (
     <>
       <ArticleCard article={articleData} />
-      {user ? <AddComment setCommentList={setCommentList} article_id={articleData.article_id}/> : null}
+      {user ? (
+        <AddComment
+          setCommentList={setCommentList}
+          article_id={articleData.article_id}
+          setArticleData={setArticleData}
+        />
+      ) : null}
       <div id="comments">
         <Box component="div">
           <Typography variant="h5">
-            Comments {commentList.length ? `(${commentList.length})` : null}
+            Comments{" "}
+            {articleData.comment_count
+              ? `(${articleData.comment_count})`
+              : null}
           </Typography>
         </Box>
         {commentList.length ? (
           commentList.map((comment) => {
-            return <CommentCard key={comment.comment_id} comment={comment} />;
+            return (
+              <CommentCard
+                key={comment.comment_id}
+                comment={comment}
+                setCommentList={setCommentList}
+                setArticleData={setArticleData}
+              />
+            );
           })
         ) : (
           <Card sx={{ maxWidth: 800, minWidth: 300, marginTop: 1, padding: 1 }}>


### PR DESCRIPTION
Added comment deleting for users. Only shows on user's own comments. Will lock out while making the API request and on success re-render the list and update articles total comment count. Done without making new API requests so user can see 'live' deletion. 